### PR TITLE
Remote http trigger

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,7 +127,7 @@ if __name__ == '__main__':
 
     if soundApp.data:
         logging.debug("Data: {}".format(soundApp.data))
-        if "-l" in sys.argv[1:]:
+        if "--http" in sys.argv[1:]:
             logging.info('Running in http listening mode')
             app.run(debug=True, host='0.0.0.0', port=8080)
         else:

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ def reload():
 @app.route('/list', methods=['GET'])
 def list():
     print("Listing songs...")
-    return jsonResponse(soundApp.data)
+    return jsonResponse(soundApp.data["songs"])
 
 if __name__ == '__main__':
     soundApp.updateData()

--- a/main.py
+++ b/main.py
@@ -127,7 +127,13 @@ if __name__ == '__main__':
 
     if soundApp.data:
         logging.debug("Data: {}".format(soundApp.data))
-        app.run(debug=True, host='0.0.0.0', port=8081)
+        if "-l" in sys.argv[1:]:
+            logging.info('Running in http listening mode')
+            app.run(debug=True, host='0.0.0.0', port=8080)
+        else:
+            logging.info('Running in local mode')
+            soundApp.playSongWithPath(soundApp.songsFolder+'/init.mp3')
+            soundApp.readInput()
     else:
         logging.error('Data is empty')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests==2.19.0
+flask
 python-firebase
 firebase-admin
 google-cloud-firestore


### PR DESCRIPTION
Se reemplaza la escucha de input desde teclado por un servicio de escucha http mediante flask en el puerto 8081, el cual quedara escuchando paths del tipo `/play/<soundID>`, en primera instancia este `soundID` representa el valor numérico del sonido a reproducir, por lo cual `/play/14` tendría como resultado `la ñiñi`.

Endpoints:
 - `/play/<soundID>` reproduce el sonido `<soundID>` en caso de que exista
 - `/stop` detiene todos los sonidos en ejecución
 - `/reload` recarga la información de los sonidos
 - `/list` muestra una lista de los sonidos actualmente cargados

Este servidor http se levantara solo si se pasa el flag `--http` al momento de ejecutar el script, de no venir el flag el funcionamiento será el mismo que se ha visto hasta ahora.

Ejemplo: `python3.7 main.py --http`

[JIRA](https://www.youtube.com/watch?v=dQw4w9WgXcQ)